### PR TITLE
Add DS Principles interactive site

### DIFF
--- a/ds-principles-interactive/README.md
+++ b/ds-principles-interactive/README.md
@@ -1,0 +1,14 @@
+# DS Principles Interactive
+
+Mini-sitio web interactivo que muestra los conceptos principales de la Fase 1 del temario.
+
+## Uso
+
+Clona este repositorio y abre `index.html` en tu navegador.
+
+```
+ git clone <repo-url>
+ open index.html
+```
+
+Cada lección es una página que se carga mediante el hash de la URL.

--- a/ds-principles-interactive/assets/datasets/sales.csv
+++ b/ds-principles-interactive/assets/datasets/sales.csv
@@ -1,0 +1,1 @@
+month,sales\nJan,10\nFeb,15\nMar,7

--- a/ds-principles-interactive/css/style.css
+++ b/ds-principles-interactive/css/style.css
@@ -1,0 +1,44 @@
+:root {
+  --bg-color: #f9f9f9;
+  --accent-color: #1e90ff;
+  --card-bg: #fff;
+  --shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: var(--bg-color);
+  color: #333;
+}
+header {
+  background: var(--card-bg);
+  box-shadow: var(--shadow);
+  position: fixed;
+  top: 0; left:0; right:0;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding: 0.5rem 1rem;
+  z-index:100;
+}
+.logo { font-weight:bold; }
+main { padding: 80px 1rem 1rem; min-height: 80vh; }
+footer { text-align:center; padding:1rem; background:var(--card-bg); box-shadow: var(--shadow); }
+.card {
+  background: var(--card-bg);
+  box-shadow: var(--shadow);
+  border-radius: 4px;
+  padding:1rem;
+  margin:0.5rem;
+  transition: transform .3s;
+}
+.card:hover { transform: translateY(-3px); }
+.stage { display:flex; flex-direction:column; align-items:center; padding:1rem; margin:0.5rem; background:var(--card-bg); box-shadow: var(--shadow); border-radius:4px; animation: slide-in .6s ease-out both; }
+@keyframes slide-in {
+  from { transform: translateY(40px); opacity:0; }
+  to { transform: translateY(0); opacity:1; }
+}
+
+@media (min-width:600px) {
+  .stages { display:flex; justify-content:space-around; }
+}

--- a/ds-principles-interactive/index.html
+++ b/ds-principles-interactive/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Data Science Principles</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <div class="logo">DS Principles</div>
+    <nav class="navbar"></nav>
+  </header>
+  <main id="app"></main>
+  <footer>
+    Interactive guide based on Phase 1 curriculum. <a href="https://github.com/">Repo</a>
+  </footer>
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/ds-principles-interactive/js/components/card.js
+++ b/ds-principles-interactive/js/components/card.js
@@ -1,0 +1,13 @@
+class LessonCard extends HTMLElement {
+  connectedCallback() {
+    const title = this.getAttribute('title');
+    const link = this.getAttribute('link');
+    this.innerHTML = `
+      <div class="card">
+        <h3>${title}</h3>
+        <a href="${link}">Go to lesson</a>
+      </div>
+    `;
+  }
+}
+customElements.define('lesson-card', LessonCard);

--- a/ds-principles-interactive/js/components/navbar.js
+++ b/ds-principles-interactive/js/components/navbar.js
@@ -1,0 +1,15 @@
+class NavBar extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="#lifecycle">Lifecycle</a></li>
+        <li><a href="#eda">EDA</a></li>
+        <li><a href="#stats">Stats</a></li>
+        <li><a href="#ethics">Ethics</a></li>
+        <li><a href="#reproducibility">Reproducibility</a></li>
+      </ul>
+    `;
+  }
+}
+customElements.define('nav-bar', NavBar);

--- a/ds-principles-interactive/js/lessons/01-lifecycle.js
+++ b/ds-principles-interactive/js/lessons/01-lifecycle.js
@@ -1,0 +1,27 @@
+export default async function lifecycleLesson() {
+  const container = document.createElement('div');
+  container.innerHTML = `
+    <h2>Data Lifecycle</h2>
+    <div class="stages">
+      <div class="stage" data-step="Collection">📥<span>Collection</span><button>Learn More</button></div>
+      <div class="stage" data-step="Cleaning">🧹<span>Cleaning</span><button>Learn More</button></div>
+      <div class="stage" data-step="Exploration">🔍<span>Exploration</span><button>Learn More</button></div>
+      <div class="stage" data-step="Model">🤖<span>Model</span><button>Learn More</button></div>
+      <div class="stage" data-step="Deploy">🚀<span>Deploy</span><button>Learn More</button></div>
+    </div>
+    <div id="modal" class="hidden"></div>
+  `;
+
+  const modal = container.querySelector('#modal');
+  container.addEventListener('click', (e) => {
+    if(e.target.tagName === 'BUTTON') {
+      const step = e.target.parentElement.dataset.step;
+      modal.className = 'modal';
+      modal.innerHTML = `<div class="card"><h3>${step}</h3><pre>// code snippet</pre><button id="close">Close</button></div>`;
+    }
+    if(e.target.id === 'close') {
+      modal.className = 'hidden';
+    }
+  });
+  return container;
+}

--- a/ds-principles-interactive/js/lessons/02-eda.js
+++ b/ds-principles-interactive/js/lessons/02-eda.js
@@ -1,0 +1,5 @@
+export default async function() {
+  const div = document.createElement('div');
+  div.innerHTML = '<h2>EDA (coming soon)</h2>';
+  return div;
+}

--- a/ds-principles-interactive/js/lessons/03-stats-thinking.js
+++ b/ds-principles-interactive/js/lessons/03-stats-thinking.js
@@ -1,0 +1,5 @@
+export default async function() {
+  const div = document.createElement('div');
+  div.innerHTML = '<h2>Statistical Thinking (coming soon)</h2>';
+  return div;
+}

--- a/ds-principles-interactive/js/lessons/04-ethics.js
+++ b/ds-principles-interactive/js/lessons/04-ethics.js
@@ -1,0 +1,5 @@
+export default async function() {
+  const div = document.createElement('div');
+  div.innerHTML = '<h2>Data Ethics (coming soon)</h2>';
+  return div;
+}

--- a/ds-principles-interactive/js/lessons/05-reproducibility.js
+++ b/ds-principles-interactive/js/lessons/05-reproducibility.js
@@ -1,0 +1,5 @@
+export default async function() {
+  const div = document.createElement('div');
+  div.innerHTML = '<h2>Reproducibility (coming soon)</h2>';
+  return div;
+}

--- a/ds-principles-interactive/js/main.js
+++ b/ds-principles-interactive/js/main.js
@@ -1,0 +1,45 @@
+import './components/navbar.js';
+import './components/card.js';
+
+const app = document.getElementById('app');
+
+const routes = {
+  lifecycle: () => import('./lessons/01-lifecycle.js'),
+  eda: () => import('./lessons/02-eda.js'),
+  stats: () => import('./lessons/03-stats-thinking.js'),
+  ethics: () => import('./lessons/04-ethics.js'),
+  reproducibility: () => import('./lessons/05-reproducibility.js'),
+};
+
+function landing() {
+  app.innerHTML = '';
+  const lessons = [
+    {hash: '#lifecycle', title: 'Data Lifecycle'},
+    {hash: '#eda', title: 'Exploratory Data Analysis'},
+    {hash: '#stats', title: 'Statistical Thinking'},
+    {hash: '#ethics', title: 'Data Ethics'},
+    {hash: '#reproducibility', title: 'Reproducibility'},
+  ];
+  lessons.forEach(l => {
+    const card = document.createElement('lesson-card');
+    card.setAttribute('title', l.title);
+    card.setAttribute('link', l.hash);
+    app.appendChild(card);
+  });
+}
+
+async function router() {
+  const hash = location.hash.replace('#','');
+  if(!hash) { landing(); return; }
+  const load = routes[hash];
+  if(load) {
+    const mod = await load();
+    app.innerHTML = '';
+    app.appendChild(await mod.default());
+  } else {
+    landing();
+  }
+}
+
+window.addEventListener('hashchange', router);
+window.addEventListener('DOMContentLoaded', router);


### PR DESCRIPTION
## Summary
- add interactive HTML/CSS/JS scaffolding for Data Science Principles lessons
- include simple router and lesson placeholders
- provide sample dataset and readme instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d664e51708330a47c9382a310c142